### PR TITLE
retry connections with a lower timeout to harden against dropped hostname lookups

### DIFF
--- a/lib/active_record/connection_adapters/mysql_flexmaster_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql_flexmaster_adapter.rb
@@ -29,9 +29,9 @@ module ActiveRecord
       class NoServerAvailableException < StandardError; end
 
       CHECK_EVERY_N_SELECTS = 10
-      DEFAULT_CONNECT_TIMEOUT = 2
+      DEFAULT_CONNECT_TIMEOUT = 1
       DEFAULT_CONNECT_RETRIES = 2
-      DEFAULT_TX_HOLD_TIMEOUT = 6
+      DEFAULT_TX_HOLD_TIMEOUT = 5
 
       def initialize(logger, config)
         @select_counter = 0


### PR DESCRIPTION
resolv.conf has a default timeout of 5 seconds before it re-requests queries. Currently if the packet to lookup a database's hostname is dropped, flexmaster's own connection timeout will raise before the resolver can re-request a lookup. This change subverts the system timeout by lifting a lower timeout and retry logic from the system into flexmaster itself, which gives you resolution timeout control in scenarios where resolv.conf is out of your control.

We could alternatively raise the timeout above the system default (e.g. 6 seconds), but this would be slightly slower.

/cc @osheroff @yadavsaroj